### PR TITLE
Fix debug comment to match reality

### DIFF
--- a/files/process.go
+++ b/files/process.go
@@ -300,7 +300,7 @@ func inList(needle string, haystack string) (bool, error) {
 		log.Debugf("Scanned line %d from %q: %q\n", lineno, haystack, currentLine)
 
 		currentLine = strings.TrimSpace(currentLine)
-		log.Debugf("Line %d from %q after lowercasing and whitespace removal: %q\n",
+		log.Debugf("Line %d from %q after whitespace removal: %q\n",
 			lineno, haystack, currentLine)
 
 		// explicitly ignore comments


### PR DESCRIPTION
As noted on the GitHub issue, the prior text could have led
to a good bit of confusion when debugging in the future. This
commit removes the invalid reference to case-folding.

fixes GH-38