### PR TITLE
Fix TCP port range recommendation order

### DIFF
--- a/config/validate.go
+++ b/config/validate.go
@@ -63,10 +63,10 @@ func validate(c Config) error {
 	case (c.LocalTCPPort() >= TCPDynamicPrivatePortStart) && (c.LocalTCPPort() <= TCPDynamicPrivatePortEnd):
 		log.Warnf(
 			"WARNING: Valid, non-privileged, but dynamic/private port between %d and %d configured. This range is reserved for dynamic (usually outgoing) connections. If you encounter errors with this application, please re-run this application and specify a port number between %d and %d",
-			TCPUserPortStart,
-			TCPUserPortEnd,
 			TCPDynamicPrivatePortStart,
 			TCPDynamicPrivatePortEnd,
+			TCPUserPortStart,
+			TCPUserPortEnd,
 		)
 
 	default:


### PR DESCRIPTION
Flip start/end port range sets so that advice is given to use a port within the non-privileged user port
range as intended. 

fixes GH-66
