### PR TITLE
Force lowercase folding for disabled username

### DIFF
--- a/files/files.go
+++ b/files/files.go
@@ -20,6 +20,7 @@ package files
 
 import (
 	"os"
+	"strings"
 	"text/template"
 
 	"github.com/atc0005/brick/events"
@@ -162,9 +163,20 @@ func NewReportedUserEventsLog(path string, permissions os.FileMode) *ReportedUse
 // already set.
 func NewDisabledUsers(path string, entrySuffix string, permissions os.FileMode) *DisabledUsers {
 
-	// parse templates
-	disabledUsersFileTemplate := template.Must(template.New(
-		"disabledUsersFileTemplate").Parse(disabledUsersFileTemplateText))
+	// parse template for disabled users file, provide a ToLower template
+	// function that can be used to case-fold values written to the disabled
+	// users file
+	disabledUsersFileTemplate := template.Must(
+		template.New(
+			"disabledUsersFileTemplate",
+		).Funcs(
+			template.FuncMap{
+				"ToLower": strings.ToLower,
+			},
+		).Parse(
+			disabledUsersFileTemplateText,
+		),
+	)
 
 	du := DisabledUsers{
 		FlatFile: FlatFile{

--- a/files/templates.go
+++ b/files/templates.go
@@ -21,7 +21,7 @@ package files
 
 const disabledUsersFileTemplateText string = `
 # Username "{{ .Username }}" from source IP "{{ .UserIP }}" disabled at "{{ .ArrivalTime }}" per alert "{{ .AlertName }}" received by "{{ .PayloadSenderIP }}" (SearchID: "{{ .SearchID }}")
-{{ .Username }}{{ .EntrySuffix }}
+{{ ToLower .Username }}{{ .EntrySuffix }}
 `
 
 // This is a standard message and only indicates that a report was received,


### PR DESCRIPTION
- add template `ToLower` func that maps to `strings.ToLower`
- force lowercase for disabled username entry by calling template function against `.Username`

Note: Intentionally leaving the comment for the disabled entry as the original case. This could potentially provide
useful metadata later regarding how the username was submitted.

fixes GH-63