### PR TITLE
Update tested list: Remove Windows 10, fail2ban

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -26,14 +26,7 @@
 The `brick` application has been tested with:
 
 - Go 1.13+
-- Windows 10 Version 1903+ (limited)
-  - native
-  - WSL
 - Ubuntu Linux 16.04, 18.04
-
-However, `brick` relies upon `fail2ban` to temporarily ban offending IPs in
-order to force login sessions to timeout. No Windows equivalent has been
-identified at this time.
 
 ## Instructions
 


### PR DESCRIPTION
- Windows 10 no longer fits (it only did during the initial design where ezproxy wasn't directly involved)

- fail2ban is one two supported ways to handle terminating user sessions and in the prior context the mention of it was specific to Windows (lack of) support