### PR TITLE
Fix invalid function call in validation func

### DIFF
--- a/config/validate.go
+++ b/config/validate.go
@@ -56,7 +56,7 @@ func validate(c Config) error {
 			"Valid, non-privileged user port between %d and %d configured: %d",
 			TCPUserPortStart,
 			TCPUserPortEnd,
-			c.LocalTCPPort,
+			c.LocalTCPPort(),
 		)
 
 	// WARNING: User opted to use a dynamic or private TCP port


### PR DESCRIPTION
The function was missing the parenthesis needed to trigger the function call.

fixes GH-83