### PR TITLE
Re-enable separate golint cmd, fix linting issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ lintinstall:
 	@export PATH="${PATH}:$(go env GOPATH)/bin"
 
 	@echo "Explicitly enabling Go modules mode per command"
+	(cd; GO111MODULE="on" go get golang.org/x/lint/golint)
 	(cd; GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck)
 
 	@echo Installing golangci-lint ${GOLANGCI_LINT_VERSION} per official binary installation docs ...
@@ -99,6 +100,9 @@ linting:
 
 	@echo "Running golangci-lint ..."
 	@golangci-lint run
+
+	@echo "Running golint separately (temporarily; see atc0005/brick#92) ..."
+	@golint -set_exit_status $(shell go list -mod=vendor ./... | grep -v /vendor/)
 
 	@echo "Running staticcheck ..."
 	@staticcheck $(shell go list -mod=vendor ./... | grep -v /vendor/)

--- a/cmd/brick/constants.go
+++ b/cmd/brick/constants.go
@@ -16,4 +16,5 @@
 
 package main
 
+// MB represents 1 Megabyte
 const MB int64 = 1048576

--- a/cmd/es/main.go
+++ b/cmd/es/main.go
@@ -35,6 +35,7 @@ import (
 const myAppName string = "es"
 const myAppURL string = "https://github.com/atc0005/brick"
 
+// AppConfig represents the configuration used by this application
 type AppConfig struct {
 
 	// Username is the name of the user account that we are searching for.

--- a/cmd/ezproxy/main.go
+++ b/cmd/ezproxy/main.go
@@ -29,6 +29,8 @@ import (
 	"github.com/atc0005/go-ezproxy"
 )
 
+// Results is used to group together potential exit codes and output in a
+// slice to be chosen pseudo-randomly.
 type Results struct {
 	ExitOutput string
 	ExitCode   int

--- a/config/getters.go
+++ b/config/getters.go
@@ -392,7 +392,7 @@ func (c Config) EmailNotificationRetries() int {
 	return 0
 }
 
-// EmailNotificationRetries returns the user-provided delay for email
+// EmailNotificationRetryDelay returns the user-provided delay for email
 // notifications or the default value if not provided. CLI flag values take
 // precedence if provided.
 func (c Config) EmailNotificationRetryDelay() int {

--- a/events/validate.go
+++ b/events/validate.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 )
 
+// ValidatePayload is used to perform very basic validation on all expected
+// fields for the received payload.
 func ValidatePayload(payloadV2 SplunkAlertPayloadV2) error {
 
 	// The `SplunkAlertPayloadV2` type is currently composed of string fields


### PR DESCRIPTION
- Update Makefile to add separate, explicit golint command against all content *except* for vendored deps
  - this is until the golangci-lint tool can be fixed or whatever configuration setting that I am not applying can be tweaked

- Fix "exported const XYZ should have comment or be unexported" linting issues

fixes GH-92