### PR TITLE
Update atc0005/send2teams from v0.4.4 to v0.4.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,6 @@ require (
 	github.com/atc0005/go-ezproxy v0.1.3
 	// temporarily use our fork; waiting on changes to be accepted upstream
 	github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726
-	github.com/atc0005/send2teams v0.4.4
+	github.com/atc0005/send2teams v0.4.5
 	github.com/pelletier/go-toml v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/atc0005/go-ezproxy v0.1.3 h1:WUKa8wTYkjrZfKM3v7MoAeeEuYmgkjdrA2s5F2Yb
 github.com/atc0005/go-ezproxy v0.1.3/go.mod h1:petHyxg0DLcJTNRmLRV5k4hx/qdVTR8Ns81UFhugw6Y=
 github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726 h1:pUJFxj7XRR6UxgWTvG4BCf1cVsn7nNqxdigBhMd1r/c=
 github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726/go.mod h1:zUADEXrhalWyaQvxzYgHswljBWycIpX1UAFrggjcdi4=
-github.com/atc0005/send2teams v0.4.4 h1:d7OfycX7MEcF088Ohy/QdgUT0dkYdw9xPr/E7EMDwXQ=
-github.com/atc0005/send2teams v0.4.4/go.mod h1:uS4e7eZnRBhY/ia8crocFu3PM2Rl0VxHGA+r3Rb8eXo=
+github.com/atc0005/send2teams v0.4.5 h1:VJ6hbMJ/oAJcmb1BxbjZOVOLwrQD+DT6IKbrFhI8iEI=
+github.com/atc0005/send2teams v0.4.5/go.mod h1:86mW/aTXHOItQ/kHnfIx/5QDzLjZK09/baa+XxBYisE=
 github.com/aws/aws-sdk-go v1.20.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -95,8 +95,6 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,7 +14,7 @@ github.com/atc0005/go-ezproxy
 github.com/atc0005/go-ezproxy/activefile
 # github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726
 github.com/atc0005/go-teams-notify
-# github.com/atc0005/send2teams v0.4.4
+# github.com/atc0005/send2teams v0.4.5
 github.com/atc0005/send2teams/teams
 # github.com/fatih/color v1.7.0
 github.com/fatih/color


### PR DESCRIPTION
- Update `go.mod` to reflect new version
- `go mod tidy`
- `go mod vendor`

Worth noting:

Running `go mod tidy` also applied changes unrelated to the `atc0005/send2teams` dep update to the go.sum file.

These changes were for the `go-yaml/yaml` package which was recently updated.