### PR TITLE
golangci-lint | Disable default exclusions in cfg

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+issues:
+  # equivalent CLI flag: --exclude-use-default
+  #
+  # see:
+  #   atc0005/brick#92
+  #   golangci-lint/golangci-lint#1249
+  #   golangci-lint/golangci-lint#413
+  exclude-use-default: false
+
 linters:
   enable:
     - dogsled

--- a/Makefile
+++ b/Makefile
@@ -101,9 +101,6 @@ linting:
 	@echo "Running golangci-lint ..."
 	@golangci-lint run
 
-	@echo "Running golint separately (temporarily; see atc0005/brick#92) ..."
-	@golint -set_exit_status $(shell go list -mod=vendor ./... | grep -v /vendor/)
-
 	@echo "Running staticcheck ..."
 	@staticcheck $(shell go list -mod=vendor ./... | grep -v /vendor/)
 


### PR DESCRIPTION
- Remove golint call from Makefile
- Remove `--exclude-use-default` CLI flag
- Add explicit config settings to disable default exclusions

This same config change will need to be pushed to all other
repos where I am using this config set.

Note to self: Docker container sooner than later perhaps?

- refs atc0005/brick#92
- refs atc0005/todo#29
- refs atc0005/todo#22