### PR TITLE
Update atc0005/go-ezproxy from v0.1.3 to v0.1.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/Showmax/go-fqdn v0.0.0-20180501083314-6f60894d629f
 	github.com/alexflint/go-arg v1.3.0
 	github.com/apex/log v1.6.0
-	github.com/atc0005/go-ezproxy v0.1.3
+	github.com/atc0005/go-ezproxy v0.1.4
 	// temporarily use our fork; waiting on changes to be accepted upstream
 	github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726
 	github.com/atc0005/send2teams v0.4.5

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/apex/log v1.6.0/go.mod h1:x7s+P9VtvFBXge9Vbn+8TrqKmuzmD35TTkeBHul8UtY
 github.com/apex/logs v1.0.0/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
-github.com/atc0005/go-ezproxy v0.1.3 h1:WUKa8wTYkjrZfKM3v7MoAeeEuYmgkjdrA2s5F2YbgP4=
-github.com/atc0005/go-ezproxy v0.1.3/go.mod h1:petHyxg0DLcJTNRmLRV5k4hx/qdVTR8Ns81UFhugw6Y=
+github.com/atc0005/go-ezproxy v0.1.4 h1:WG3/zdb/NS4zVulaw7XNSmjIOTfV4XxeqWu5GHV49R0=
+github.com/atc0005/go-ezproxy v0.1.4/go.mod h1:petHyxg0DLcJTNRmLRV5k4hx/qdVTR8Ns81UFhugw6Y=
 github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726 h1:pUJFxj7XRR6UxgWTvG4BCf1cVsn7nNqxdigBhMd1r/c=
 github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726/go.mod h1:zUADEXrhalWyaQvxzYgHswljBWycIpX1UAFrggjcdi4=
 github.com/atc0005/send2teams v0.4.5 h1:VJ6hbMJ/oAJcmb1BxbjZOVOLwrQD+DT6IKbrFhI8iEI=

--- a/vendor/github.com/atc0005/go-ezproxy/.golangci.yml
+++ b/vendor/github.com/atc0005/go-ezproxy/.golangci.yml
@@ -14,6 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+issues:
+  # equivalent CLI flag: --exclude-use-default
+  #
+  # see:
+  #   atc0005/brick#92
+  #   atc0005/go-ezproxy#28
+  #   golangci-lint/golangci-lint#1249
+  #   golangci-lint/golangci-lint#413
+  exclude-use-default: false
+
 linters:
   enable:
     - depguard

--- a/vendor/github.com/atc0005/go-ezproxy/CHANGELOG.md
+++ b/vendor/github.com/atc0005/go-ezproxy/CHANGELOG.md
@@ -26,6 +26,31 @@ The following types of changes will be recorded in this file:
 
 - placeholder
 
+## [v0.1.4] - 2020-07-23
+
+### Changed
+
+- Dependencies
+  - updated `actions/setup-go`
+    - `v2.1.0` to `v2.1.1`
+  - updated `actions/setup-node`
+    - `v2.1.0` to `v2.1.1`
+
+- Linting
+  - `golangci-lint`: Disable default exclusions
+
+- Logging
+  - log original and sanitized filenames
+
+### Fixed
+
+- Linting
+  - gosec: Wrap os.Open calls with filepath.Clean
+  - golint: comment on exported const XYZ should be of the form XYZ ...
+  - gosec (G204): Mute subprocess linting error for intentional `exec.Command`
+    call which uses a a client-provided value
+  - errcheck: Explicitly check file close return values
+
 ## [v0.1.3] - 2020-07-02
 
 ### Changed
@@ -142,7 +167,8 @@ application is released (currently pending review).
 
 <!-- Version header ref links here  -->
 
-[Unreleased]: https://github.com/atc0005/go-ezproxy/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/atc0005/go-ezproxy/compare/v0.1.4...HEAD
+[v0.1.4]: https://github.com/atc0005/go-ezproxy/releases/tag/v0.1.4
 [v0.1.3]: https://github.com/atc0005/go-ezproxy/releases/tag/v0.1.3
 [v0.1.2]: https://github.com/atc0005/go-ezproxy/releases/tag/v0.1.2
 [v0.1.1]: https://github.com/atc0005/go-ezproxy/releases/tag/v0.1.1

--- a/vendor/github.com/atc0005/go-ezproxy/terminate.go
+++ b/vendor/github.com/atc0005/go-ezproxy/terminate.go
@@ -74,10 +74,12 @@ func TerminateUserSession(executable string, sessions ...UserSession) TerminateU
 			session.Username,
 		)
 
-		// cmd := exec.Command(
-		// 	"echo",
-		// 	"hello",
-		// )
+		// Accepting variables here is intentional; we need to provide the
+		// flexibility for client code to pass-in site-specific values. This
+		// allows for custom EZproxy installations which may place the
+		// application and associated files in a non-default location.
+		//
+		// nolint:gosec
 		cmd := exec.Command(
 			executable,
 			SubCmdNameSessionTerminate,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,7 +11,7 @@ github.com/apex/log/handlers/discard
 github.com/apex/log/handlers/json
 github.com/apex/log/handlers/logfmt
 github.com/apex/log/handlers/text
-# github.com/atc0005/go-ezproxy v0.1.3
+# github.com/atc0005/go-ezproxy v0.1.4
 github.com/atc0005/go-ezproxy
 github.com/atc0005/go-ezproxy/activefile
 # github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726


### PR DESCRIPTION
This release is mostly composed of linting fixes; this is in theme with the upcoming v0.4.1 release
of this project.

fixes GH-120