### PR TITLE
Explicit close file, mute file already closed errs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -242,11 +243,14 @@ func NewConfig() (*Config, error) {
 		}
 		defer func() {
 			if err := fh.Close(); err != nil {
-				log.Errorf(
-					"%s: failed to close file %q: %s",
-					myFuncName,
-					err.Error(),
-				)
+				// Ignore "file already closed" errors
+				if !errors.Is(err, os.ErrClosed) {
+					log.Errorf(
+						"%s: failed to close file %q: %s",
+						myFuncName,
+						err.Error(),
+					)
+				}
 			}
 		}()
 		log.Debugf("%s: Config file %q opened", myFuncName, sanitizedFilePath)


### PR DESCRIPTION
## Changes

Copy behavior from `config.NewConfig` to `fileutils.HasLine` to order to explicitly close open files. This allows us to return the error immediately if no more serious errors occur before the file closure attempt, while still getting the file closure attempt in if there are more serious errors that force an early termination.

Update deferred file closures so that "file already closed" error messages are ignored; because we have already explicitly closed the file, finding that it is already closed is perfectly OK.

## References

- fixes atc0005/brick#127
- refs atc0005/go-ezproxy#38