### PR TITLE
Alert sender: Replace "received by" phrasing

### DIFF
--- a/contrib/fail2ban/filter.d/brick.local
+++ b/contrib/fail2ban/filter.d/brick.local
@@ -27,7 +27,7 @@
 
 [Definition]
 
-# {{ .ArrivalTime }} [DISABLED] Username "{{ .Username }}" from source IP "{{ .UserIP }}" disabled due to alert "{{ .AlertName }}" received by "{{ .PayloadSenderIP }}" (SearchID: "{{ .SearchID }}")
+# {{ .ArrivalTime }} [DISABLED] Username "{{ .Username }}" from source IP "{{ .UserIP }}" disabled due to alert "{{ .AlertName }}" received from "{{ .PayloadSenderIP }}" (SearchID: "{{ .SearchID }}")
 failregex = \[DISABLED\] Username \"[a-zA-Z0-9]+\" from source IP \"<HOST>\"
 
 # Option:  ignoreregex

--- a/events/record.go
+++ b/events/record.go
@@ -49,7 +49,7 @@ const (
 
 // Record is a collection of details that is saved to log files, sent by
 // Microsoft Teams or email; this is a superset of types. This type contains
-// the core details received by the alert payload and select annotations
+// the core details provided by the alert payload and select annotations
 // associated with processing the alert payload.
 type Record struct {
 

--- a/files/templates.go
+++ b/files/templates.go
@@ -20,20 +20,20 @@ package files
 // order to increase fail2ban parsing reliability
 
 const disabledUsersFileTemplateText string = `
-# Username "{{ .Alert.Username }}" from source IP "{{ .Alert.UserIP }}" disabled at "{{ .Alert.ArrivalTime }}" per alert "{{ .Alert.AlertName }}" received by "{{ .Alert.PayloadSenderIP }}" (SearchID: "{{ .Alert.SearchID }}")
+# Username "{{ .Alert.Username }}" from source IP "{{ .Alert.UserIP }}" disabled at "{{ .Alert.ArrivalTime }}" per alert "{{ .Alert.AlertName }}" received from "{{ .Alert.PayloadSenderIP }}" (SearchID: "{{ .Alert.SearchID }}")
 {{ ToLower .Alert.Username }}{{ .EntrySuffix }}
 `
 
 // This is a standard message and only indicates that a report was received,
 // not that a user was disabled. This message should be followed by another
 // message indicating whether the user was disabled or ignored
-const reportedUserEventTemplateText string = `{{ .Alert.ArrivalTime }} [REPORTED] Username "{{ .Alert.Username }}" from source IP "{{ .Alert.UserIP }}" reported via alert "{{ .Alert.AlertName }}" received by "{{ .Alert.PayloadSenderIP }}" (SearchID: "{{ .Alert.SearchID }}")
+const reportedUserEventTemplateText string = `{{ .Alert.ArrivalTime }} [REPORTED] Username "{{ .Alert.Username }}" from source IP "{{ .Alert.UserIP }}" reported via alert "{{ .Alert.AlertName }}" received from "{{ .Alert.PayloadSenderIP }}" (SearchID: "{{ .Alert.SearchID }}")
 `
 
-const disabledUserFirstEventTemplateText string = `{{ .Alert.ArrivalTime }} [DISABLED] Username "{{ .Alert.Username }}" from source IP "{{ .Alert.UserIP }}" disabled due to alert "{{ .Alert.AlertName }}" received by "{{ .Alert.PayloadSenderIP }}" (SearchID: "{{ .Alert.SearchID }}")
+const disabledUserFirstEventTemplateText string = `{{ .Alert.ArrivalTime }} [DISABLED] Username "{{ .Alert.Username }}" from source IP "{{ .Alert.UserIP }}" disabled due to alert "{{ .Alert.AlertName }}" received from "{{ .Alert.PayloadSenderIP }}" (SearchID: "{{ .Alert.SearchID }}")
 `
 
-const disabledUserRepeatEventTemplateText string = `{{ .Alert.ArrivalTime }} [DISABLED] Username "{{ .Alert.Username }}" from source IP "{{ .Alert.UserIP }}" already disabled, but would be again due to alert "{{ .Alert.AlertName }}" received by "{{ .Alert.PayloadSenderIP }}" (SearchID: "{{ .Alert.SearchID }}")
+const disabledUserRepeatEventTemplateText string = `{{ .Alert.ArrivalTime }} [DISABLED] Username "{{ .Alert.Username }}" from source IP "{{ .Alert.UserIP }}" already disabled, but would be again due to alert "{{ .Alert.AlertName }}" received from "{{ .Alert.PayloadSenderIP }}" (SearchID: "{{ .Alert.SearchID }}")
 `
 
 // NOTE: This template is used for ignored users and IP Addresses based on
@@ -44,5 +44,5 @@ const ignoredUserEventTemplateText string = `{{ .Alert.ArrivalTime }} [IGNORED] 
 // This template is used to write out the results of each session termination
 // attempt; this template is not used to generate a bulk summary for multiple
 // sessions
-const terminatedUserEventTemplateText string = `{{ .Alert.ArrivalTime }} [TERMINATED] Session "{{ .UserSession.SessionID }}" associated with {{ .UserSession.IPAddress }} for username "{{ .Alert.Username }}" from source IP "{{ .Alert.UserIP }}" terminated due to alert "{{ .Alert.AlertName }}" received by "{{ .Alert.PayloadSenderIP }}" (SearchID: "{{ .Alert.SearchID }}")
+const terminatedUserEventTemplateText string = `{{ .Alert.ArrivalTime }} [TERMINATED] Session "{{ .UserSession.SessionID }}" associated with {{ .UserSession.IPAddress }} for username "{{ .Alert.Username }}" from source IP "{{ .Alert.UserIP }}" terminated due to alert "{{ .Alert.AlertName }}" received from "{{ .Alert.PayloadSenderIP }}" (SearchID: "{{ .Alert.SearchID }}")
 `


### PR DESCRIPTION
Replace with "received from" to better communicate that the information comes *from* the specified source, not provided to it.

This mostly involves updating the file templates and the fail2ban template rule, but also includes a doc comment tweak to clarify the same logic.

fixes GH-131