### PR TITLE
Use generated email summary instead of Record.Note

### DIFF
--- a/cmd/brick/templates.go
+++ b/cmd/brick/templates.go
@@ -22,7 +22,7 @@ package main
 
 		Top-level Title
 
-		Introduction block (e.g., msgCard.Text)
+		Introduction / Summary block (e.g., msgCard.Text)
 
 		Errors Section
 
@@ -42,8 +42,8 @@ const defaultEmailTemplate string = `
 
 **Summary**
 
-{{ if ne .Record.Note "" -}}
-{{ .Record.Note }}
+{{ if ne .EmailSummary "" -}}
+{{ .EmailSummary }}
 {{- else -}}
 {{ $missingValue }}
 {{- end }}
@@ -93,8 +93,8 @@ const textileEmailTemplate string = `
 **Summary**
 
 <pre>
-{{ if ne .Record.Note "" -}}
-{{ .Record.Note }}
+{{ if ne .EmailSummary "" -}}
+{{ .EmailSummary }}
 {{- else -}}
 {{ $missingValue }}
 {{- end }}

--- a/files/process.go
+++ b/files/process.go
@@ -501,6 +501,9 @@ func terminateUserSessions(
 		return events.NewRecord(
 			alert,
 			activeSessionsCountErr,
+			// Not going to set a Note here as the error message explains the
+			// problem well enough already and will be used as the
+			// notification summary if/when generated (GH-134).
 			"",
 			events.ActionFailureTerminatedUserSession,
 			nil,


### PR DESCRIPTION
## PROBLEM

By accessing the field directly, we bypass the error
handling logic already implemented for notification
message summary generation.

## CHANGES

This commit updates the email templates to use a provided
field dedicated to just the email summary value. This value
is set by the `getMsgSummaryText` func where basic
logic is being applied to return one of `Record.Note`,
`Record.Error` or a fallback string. That fallback string
has been updated to indicate that is a placeholder for
the `Record.Note` and the `Record.Error` fields if both
are missing.

This generated field value has been renamed to EmailSummary
in an effort to better indicate its purpose.

At the origin point of the missing `Record.Note` field value,
I added a brief note (pun intended?) explaining why we are
setting an empty field value and dropping a GH issue reference
for further reading.

Some doc comments were cleaned up or removed as warranted by
the other changes.

The remaining changes are mostly formatting related.

## REFERENCES

- fixes GH-134