### PR TITLE
mock ezproxy | Replace math/rand with crypto/rand

### DIFF
--- a/cmd/ezproxy/main.go
+++ b/cmd/ezproxy/main.go
@@ -17,12 +17,12 @@
 package main
 
 import (
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"os"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/apex/log"
 
@@ -122,9 +122,13 @@ func main() {
 		}
 
 		// randomly return one of the result codes from the list above
-		seed := rand.NewSource(time.Now().UnixNano())
-		rng := rand.New(seed)
-		randomResultIdx := rng.Intn(len(resultCodes))
+		maxRandomNumber := big.NewInt(int64(len(resultCodes)))
+		nBig, rngErr := rand.Int(rand.Reader, maxRandomNumber)
+		if rngErr != nil {
+			fmt.Printf("unable to generate random number: %v", rngErr)
+			os.Exit(1)
+		}
+		randomResultIdx := nBig.Int64()
 		fmt.Println(resultCodes[randomResultIdx].ExitOutput)
 		os.Exit(resultCodes[randomResultIdx].ExitCode)
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -82,6 +82,11 @@ absolutely essential) while developing this application.
   - <https://www.w3.org/TR/2016/REC-html51-20161101/sec-forms.html#email-state-typeemail>
   - <https://golangcode.com/validate-an-email-address/>
 
+- random numbers
+  - <https://gobyexample.com/random-numbers>
+  - <https://stackoverflow.com/questions/32349807/how-can-i-generate-a-random-int-using-the-crypto-rand-package>
+  - <https://github.com/securego/gosec>
+
 ### Related projects
 
 - <https://github.com/atc0005/bounce>


### PR DESCRIPTION
Replace math/rand as source for pseudorandom numbers with crypto/rand in order to resolve gosec G404 linting
error.

While this tool does not need truly random numbers for cryptographic purposes, we're going ahead and using
crypto/rand anyway to avoid potential future linting issues related to math/rand use.

fixes GH-146