### PR TITLE
Lock Maildev container to specific version

### DIFF
--- a/contrib/demo/scripts/06-reset-env.sh
+++ b/contrib/demo/scripts/06-reset-env.sh
@@ -68,7 +68,8 @@ sudo postsuper -d ALL
 
 echo "* Reset Docker container"
 sudo docker container stop maildev
-sudo docker run --rm --detach --name maildev -p 1080:80 -p 1025:25 maildev/maildev
+# Use a specific version that has proven stable during earlier demos
+sudo docker run --rm --detach --name maildev -p 1080:80 -p 1025:25 maildev/maildev:1.1.0
 
 echo "* Reset fail2ban state"
 # https://unix.stackexchange.com/questions/286119


### PR DESCRIPTION
This was meant to be included in commit b3e9c4d524a105cc83f3ff8ef44872c76a70200b.

Specify version `1.1.0` as the `maildev/maildev` container to use since it has proven stable during prior demos. The intent is to reduce "gotchas".

refs GH-140