### PR TITLE
Add termination results to email notifications

### DIFF
--- a/cmd/brick/notify.go
+++ b/cmd/brick/notify.go
@@ -667,6 +667,12 @@ func NotifyMgr(ctx context.Context, cfg *config.Config, notifyWorkQueue <-chan e
 			template.New(
 				"emailTemplate",
 			).Funcs(template.FuncMap{
+				// The name "inc" is what the function will be called in the
+				// template text.
+				// https://stackoverflow.com/a/25690905/903870
+				"inc": func(i int) int {
+					return i + 1
+				},
 				"trim": strings.TrimSpace,
 			}).Parse(activeTemplate))
 

--- a/cmd/brick/templates.go
+++ b/cmd/brick/templates.go
@@ -58,6 +58,23 @@ None
 {{- end }}
 
 
+{{ if .Record.SessionTerminationResults -}}
+**Session Termination Results**
+
+{{ range $index, $element := .Record.SessionTerminationResults -}}
+
+Session {{ inc $index }}:
+
+* SessionID: {{ .SessionID }}
+* IPAddress: {{ .IPAddress }}
+* ExitCode: {{ .ExitCode }}
+* StdOut: {{ .StdOut }}
+* StdErr: {{ .StdErr }}
+* Error: {{ .Error }}
+
+{{ end }}
+{{- end }}
+
 **Disable User Request Details**
 
 * Username: {{ if .Record.Alert.Username }}{{ .Record.Alert.Username }}{{ else }}{{ $missingValue }}{{ end }}
@@ -109,6 +126,17 @@ const textileEmailTemplate string = `
 </pre>
 {{- else -}}
 * None
+{{- end }}
+
+
+{{ if .Record.SessionTerminationResults -}}
+**Session Termination Results**
+
+| SessionID | IPAddress | ExitCode | StdOut | StdErr| Error |
+{{ range .Record.SessionTerminationResults -}}
+| {{ .SessionID }} | {{ .IPAddress }} | {{ .ExitCode }} | {{ .StdOut }} | {{ .StdErr }} | {{ .Error }} |
+{{ end }}
+{{- else -}}
 {{- end }}
 
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -87,6 +87,13 @@ absolutely essential) while developing this application.
   - <https://stackoverflow.com/questions/32349807/how-can-i-generate-a-random-int-using-the-crypto-rand-package>
   - <https://github.com/securego/gosec>
 
+- templates
+  - <https://golang.org/pkg/text/template/>
+  - <https://curtisvermeeren.github.io/2017/09/14/Golang-Templates-Cheatsheet>
+  - <https://stackoverflow.com/questions/54156119/range-over-string-slice-in-golang-template>
+  - <https://stackoverflow.com/questions/25689829/arithmetic-in-go-templates>
+    - <https://stackoverflow.com/a/25690905/903870>
+
 ### Related projects
 
 - <https://github.com/atc0005/bounce>


### PR DESCRIPTION
This section is already included in Teams notifications, but
not email notifications. This should bring both notification
types to feature parity.

Changes:

- Add inc template function to FuncMap to use with the
  `defaultEmailTemplate` to separate out session details

- Include session termination results for both templates
  only if there are session termination results to display
  - table for the textile template
  - collections of bullet points separated by a blank line

- Updated References to list sources of inspiration/assistance

fixes GH-151