### PR TITLE
Add missing filename reference in error message

### DIFF
--- a/internal/fileutils/contains.go
+++ b/internal/fileutils/contains.go
@@ -60,6 +60,7 @@ func HasLine(searchTerm string, ignorePrefix string, filename string) (bool, err
 				log.Errorf(
 					"%s: failed to close file %q: %s",
 					myFuncName,
+					filename,
 					err.Error(),
 				)
 			}


### PR DESCRIPTION
Found this while working on a different project.