### PR TITLE
Update Showmax/go-fqdn from v0.0.0-20180501083314-6f60894d629f to v1.0.0

### DIFF
--- a/config/getters.go
+++ b/config/getters.go
@@ -426,8 +426,8 @@ func (c Config) EmailClientIdentity() string {
 		// fully-qualified domain name for the system where this application
 		// is running. If there are issues resolving the fqdn use our fallback
 		// value.
-		hostname := fqdn.Get()
-		if hostname == "unknown" {
+		hostname, err := fqdn.FqdnHostname()
+		if err != nil {
 			hostname = defaultSMTPClientIdentity
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ module github.com/atc0005/brick
 go 1.14
 
 require (
-	github.com/Showmax/go-fqdn v0.0.0-20180501083314-6f60894d629f
+	github.com/Showmax/go-fqdn v1.0.0
 	github.com/alexflint/go-arg v1.3.0
 	github.com/apex/log v1.9.0
 	github.com/atc0005/go-ezproxy v0.1.6

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Showmax/go-fqdn v0.0.0-20180501083314-6f60894d629f h1:JqQetNUOVIen9o9K9c+BHgYePFGXQmedq/A6F58Xu+w=
-github.com/Showmax/go-fqdn v0.0.0-20180501083314-6f60894d629f/go.mod h1:nxfWvpOWKx1oAU7G3U8UYWL/iY6EKdjjv1w/S8HDsvg=
+github.com/Showmax/go-fqdn v1.0.0 h1:0rG5IbmVliNT5O19Mfuvna9LL7zlHyRfsSvBPZmF9tM=
+github.com/Showmax/go-fqdn v1.0.0/go.mod h1:SfrFBzmDCtCGrnHhoDjuvFnKsWjEQX/Q9ARZvOrJAko=
 github.com/alexflint/go-arg v1.3.0 h1:UfldqSdFWeLtoOuVRosqofU4nmhI1pYEbT4ZFS34Bdo=
 github.com/alexflint/go-arg v1.3.0/go.mod h1:9iRbDxne7LcR/GSvEr7ma++GLpdIU1zrghf2y2768kM=
 github.com/alexflint/go-scalar v1.0.0 h1:NGupf1XV/Xb04wXskDFzS0KWOLH632W/EO4fAFi+A70=

--- a/vendor/github.com/Showmax/go-fqdn/.golangci.yml
+++ b/vendor/github.com/Showmax/go-fqdn/.golangci.yml
@@ -1,0 +1,32 @@
+run:
+  modules-download-mode: readonly
+
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+
+  govet:
+    enable-all: true
+
+linters:
+  enable:
+    - dogsled
+    - gochecknoglobals
+    - gochecknoinits
+    - goconst
+    - gomnd
+    - goprintffuncname
+    - maligned
+    - nakedret
+    - scopelint
+    - unconvert
+    - unparam
+
+issues:
+  exclude-rules:
+    - path: _test.go$
+      linters:
+        - gomnd
+
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/vendor/github.com/Showmax/go-fqdn/README.md
+++ b/vendor/github.com/Showmax/go-fqdn/README.md
@@ -1,26 +1,31 @@
 # go-fqdn
-Simple wrapper around `net` and `os` golang standard libraries providing Fully Qualified Domain Name of the machine.
+
+Go package to provide reasonable robust access to fully qualified hostname. It
+first tries to looks up your hostname in hosts file. If that fails, it falls
+back to doing lookup via dns.
+
+Basically it tries to mirror how standard linux `hostname -f` works. For that
+reason, your hosts file should be configured properly, please refer to hosts(5)
+for that.
+
+It also has no 3rd party dependencies.
 
 ## Usage
-Get the library...
-```
-$ go get github.com/Showmax/go-fqdn
-```
-...and write some code.
-```
-package main
 
-import (
-	"fmt"
-	"github.com/Showmax/go-fqdn"
-)
+This package uses go modules, so just writing code that uses it should be
+enough. For example of usage you can check out
+[the example](examples/example_test.go).
 
-func main() {
-	fmt.Println(fqdn.Get())
-}
-```
+Documentation can be found
+[here](https://pkg.go.dev/github.com/Showmax/go-fqdn?tab=doc).
 
-`fqdn.Get()` returns:
-- machine's FQDN if found.
-- hostname if FQDN is not found.
-- return "unknown" if nothing is found.
+## Supported go versions
+
+Current and current - 1 versions of go are supported.
+
+## Known issues
+
+On macos, when **not** using cgo (`CGO_ENABLED=0`), getting the fqdn hostname
+might not work. Depends on rest of your setup and how `/etc/resolv.conf` looks
+like. Since that file is not used much (at least based on documentation) by
+macos programs, it is possible it is not in correct state.

--- a/vendor/github.com/Showmax/go-fqdn/errors.go
+++ b/vendor/github.com/Showmax/go-fqdn/errors.go
@@ -1,0 +1,51 @@
+package fqdn
+
+import "fmt"
+
+// Error for cases when os.Hostname() fails.
+var ErrHostnameFailed = errHostnameFailed{}
+
+// Error for cases when we could not found fqdn for whatever reason.
+var ErrFqdnNotFound = errFqdnNotFound{}
+
+type errHostnameFailed struct {
+	cause error
+}
+
+func (e errHostnameFailed) Error() string {
+	return fmt.Sprintf("could not get hostname: %v", e.cause)
+}
+
+func (e errHostnameFailed) Unwrap() error {
+	return e.cause
+}
+
+func (e errHostnameFailed) Is(target error) bool {
+	switch target.(type) {
+	case errHostnameFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+type errFqdnNotFound struct {
+	cause error
+}
+
+func (e errFqdnNotFound) Error() string {
+	return fmt.Sprintf("fqdn hostname not found: %v", e.cause)
+}
+
+func (e errFqdnNotFound) Unwrap() error {
+	return e.cause
+}
+
+func (e errFqdnNotFound) Is(target error) bool {
+	switch target.(type) {
+	case errFqdnNotFound:
+		return true
+	default:
+		return false
+	}
+}

--- a/vendor/github.com/Showmax/go-fqdn/fqdn.go
+++ b/vendor/github.com/Showmax/go-fqdn/fqdn.go
@@ -1,37 +1,268 @@
 package fqdn
 
 import (
+	"bufio"
+	"fmt"
+	"io"
 	"net"
 	"os"
-	"strings"
 )
 
-// Get Fully Qualified Domain Name
-// returns "unknown" or hostanme in case of error
-func Get() string {
-	hostname, err := os.Hostname()
-	if err != nil {
-		return "unknown"
+// isalnum(3p) in POSIX locale
+func isalnum(r rune) bool {
+	return (r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z') ||
+		(r >= '0' && r <= '9')
+}
+
+const (
+	maxHostnameLen = 254
+)
+
+// Validate hostname, based on musl-c version of this function.
+func isValidHostname(s string) bool {
+	if len(s) > maxHostnameLen {
+		return false
 	}
 
-	addrs, err := net.LookupIP(hostname)
-	if err != nil {
-		return hostname
-	}
-
-	for _, addr := range addrs {
-		if ipv4 := addr.To4(); ipv4 != nil {
-			ip, err := ipv4.MarshalText()
-			if err != nil {
-				return hostname
-			}
-			hosts, err := net.LookupAddr(string(ip))
-			if err != nil || len(hosts) == 0 {
-				return hostname
-			}
-			fqdn := hosts[0]
-			return strings.TrimSuffix(fqdn, ".") // return fqdn without trailing dot
+	for _, c := range s {
+		if !(c >= 0x80 || c == '.' || c == '-' || isalnum(c)) {
+			return false
 		}
 	}
-	return hostname
+
+	return true
+}
+
+func parseHostLine(host string, line string) (string, bool) {
+	const (
+		StateSkipWhite = iota
+		StateIp
+		StateCanonFirst
+		StateCanon
+		StateAliasFirst
+		StateAlias
+	)
+
+	var (
+		canon     string
+		state     int
+		nextState int
+
+		i     int
+		start int
+	)
+
+	isWhite := func(b byte) bool {
+		return b == ' ' || b == '\t'
+	}
+	isLast := func() bool {
+		return i == len(line)-1 || isWhite(line[i+1])
+	}
+	partStr := func() string {
+		return line[start : i+1]
+	}
+
+	state = StateSkipWhite
+	nextState = StateIp
+
+	debug("Looking for %q in %q", host, line)
+	for i = 0; i < len(line); i += 1 {
+		debug("%03d: character %q, state: %d, nstate: %d",
+			i, line[i], state, nextState)
+
+		if line[i] == '#' {
+			debug("%03d: found comment, terminating", i)
+			break
+		}
+
+		switch state {
+		case StateSkipWhite:
+			if !isWhite(line[i]) {
+				state = nextState
+				i -= 1
+			}
+		case StateIp:
+			if isLast() {
+				state = StateSkipWhite
+				nextState = StateCanonFirst
+			}
+		case StateCanonFirst:
+			start = i
+			state = StateCanon
+			i -= 1
+		case StateCanon:
+			debug("Canon so far: %q", partStr())
+			if isLast() {
+				canon = partStr()
+				if !isValidHostname(canon) {
+					return "", false
+				}
+
+				if canon == host {
+					debug("Canon match")
+					return canon, true
+				}
+
+				state = StateSkipWhite
+				nextState = StateAliasFirst
+			}
+		case StateAliasFirst:
+			start = i
+			state = StateAlias
+			i -= 1
+		case StateAlias:
+			debug("Alias so far: %q", partStr())
+			if isLast() {
+				alias := partStr()
+				if alias == host {
+					debug("Alias match")
+					return canon, true
+				}
+
+				state = StateSkipWhite
+				nextState = StateAliasFirst
+			}
+		default:
+			panic(fmt.Sprintf("BUG: State not handled: %d", state))
+		}
+	}
+
+	debug("No match")
+	return "", false
+}
+
+// Reads hosts(5) file and tries to get canonical name for host.
+func fromHosts(host string) (string, error) {
+	var (
+		fqdn string
+		line string
+		err  error
+		file *os.File
+		r    *bufio.Reader
+		ok   bool
+	)
+
+	file, err = os.Open(hostsPath)
+	if err != nil {
+		err = fmt.Errorf("cannot open hosts file: %w", err)
+		goto out
+	}
+	defer file.Close()
+
+	r = bufio.NewReader(file)
+	for line, err = readline(r); err == nil; line, err = readline(r) {
+		fqdn, ok = parseHostLine(host, line)
+		if ok {
+			goto out
+		}
+	}
+
+	if err != io.EOF {
+		err = fmt.Errorf("failed to read file: %w", err)
+		goto out
+	}
+	err = errFqdnNotFound{}
+
+out:
+	return fqdn, err
+}
+
+func fromLookup(host string) (string, error) {
+	var (
+		fqdn  string
+		err   error
+		addrs []net.IP
+		hosts []string
+	)
+
+	fqdn, err = net.LookupCNAME(host)
+	if err == nil && len(fqdn) != 0 {
+		debug("LookupCNAME success: %q", fqdn)
+		goto out
+	}
+	debug("LookupCNAME failed: %v", err)
+
+	debug("Looking up: %q", host)
+	addrs, err = net.LookupIP(host)
+	if err != nil {
+		err = errFqdnNotFound{err}
+		goto out
+	}
+	debug("Resolved addrs: %q", addrs)
+
+	for _, addr := range addrs {
+		debug("Trying: %q", addr)
+		hosts, err = net.LookupAddr(addr.String())
+		// On windows it can return err == nil but empty list of hosts
+		if err != nil || len(hosts) == 0 {
+			continue
+		}
+		debug("Resolved hosts: %q", hosts)
+
+		// First one should be the canonical hostname
+		fqdn = hosts[0]
+
+		goto out
+	}
+
+	err = errFqdnNotFound{}
+out:
+	// For some reason we wanted the canonical hostname without
+	// trailing dot. So if it is present, strip it.
+	if len(fqdn) > 0 && fqdn[len(fqdn)-1] == '.' {
+		fqdn = fqdn[:len(fqdn)-1]
+	}
+
+	return fqdn, err
+}
+
+// Try to get fully qualified hostname for current machine.
+//
+// It tries to mimic how `hostname -f` works, so except for few edge cases you
+// should get the same result from both. One thing that needs to be mentioned is
+// that it does not guarantee that you get back fqdn. There is no way to do that
+// and `hostname -f` can also return non-fqdn hostname if your /etc/hosts is
+// fucked up.
+//
+// It checks few sources in this order:
+//
+// 1. hosts file
+//	It parses hosts file if present and readable and returns first canonical
+//	hostname that also references your hostname. See hosts(5) for more
+//	details.
+// 2. dns lookup
+//	If lookup in hosts file fails, it tries to ask dns.
+//
+// If none of steps above succeeds, ErrFqdnNotFound is returned as error. You
+// will probably want to just use output from os.Hostname() at that point.
+func FqdnHostname() (string, error) {
+	var (
+		fqdn string
+		host string
+		err  error
+	)
+
+	host, err = os.Hostname()
+	if err != nil {
+		err = errHostnameFailed{err}
+		goto out
+	}
+	debug("Hostname: %q", host)
+
+	fqdn, err = fromHosts(host)
+	if err == nil {
+		debug("fqdn fetched from hosts: %q", fqdn)
+		goto out
+	}
+
+	fqdn, err = fromLookup(host)
+	if err == nil {
+		debug("fqdn fetched from lookup: %q", fqdn)
+		goto out
+	}
+
+	debug("fqdn fetch failed: %v", err)
+out:
+	return fqdn, err
 }

--- a/vendor/github.com/Showmax/go-fqdn/fqdn_posix.go
+++ b/vendor/github.com/Showmax/go-fqdn/fqdn_posix.go
@@ -1,0 +1,5 @@
+// +build !windows
+
+package fqdn
+
+var hostsPath = "/etc/hosts" //nolint:gochecknoglobals

--- a/vendor/github.com/Showmax/go-fqdn/fqdn_test_posix.go
+++ b/vendor/github.com/Showmax/go-fqdn/fqdn_test_posix.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package fqdn
+
+const hostnameBin = "hostname"
+
+var hostnameArgs = []string{"-f"} //nolint:gochecknoglobals

--- a/vendor/github.com/Showmax/go-fqdn/fqdn_test_win.go
+++ b/vendor/github.com/Showmax/go-fqdn/fqdn_test_win.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package fqdn
+
+const hostnameBin = "hostname"
+
+var hostnameArgs = []string{} //nolint:gochecknoglobals

--- a/vendor/github.com/Showmax/go-fqdn/fqdn_win.go
+++ b/vendor/github.com/Showmax/go-fqdn/fqdn_win.go
@@ -1,0 +1,5 @@
+// +build windows
+
+package fqdn
+
+var hostsPath = `C:\Windows\System32\drivers\etc\hosts` //nolint:gochecknoglobals

--- a/vendor/github.com/Showmax/go-fqdn/go.mod
+++ b/vendor/github.com/Showmax/go-fqdn/go.mod
@@ -1,0 +1,3 @@
+module github.com/Showmax/go-fqdn
+
+go 1.15

--- a/vendor/github.com/Showmax/go-fqdn/legacy.go
+++ b/vendor/github.com/Showmax/go-fqdn/legacy.go
@@ -1,0 +1,42 @@
+package fqdn
+
+import (
+	"net"
+	"os"
+	"strings"
+)
+
+// Get Fully Qualified Domain Name
+// returns "unknown" or hostname in case of error
+//
+// Deprecated:
+//             This function has bad API, works poorly and is replace by
+//             FqdnHostname. Please please do not use it. It *will* be removed
+//             in the next version.
+func Get() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+
+	addrs, err := net.LookupIP(hostname)
+	if err != nil {
+		return hostname
+	}
+
+	for _, addr := range addrs {
+		if ipv4 := addr.To4(); ipv4 != nil {
+			ip, err := ipv4.MarshalText()
+			if err != nil {
+				return hostname
+			}
+			hosts, err := net.LookupAddr(string(ip))
+			if err != nil || len(hosts) == 0 {
+				return hostname
+			}
+			fqdn := hosts[0]
+			return strings.TrimSuffix(fqdn, ".") // return fqdn without trailing dot
+		}
+	}
+	return hostname
+}

--- a/vendor/github.com/Showmax/go-fqdn/log.go
+++ b/vendor/github.com/Showmax/go-fqdn/log.go
@@ -1,0 +1,8 @@
+// +build !DEBUG
+
+package fqdn
+
+// Internal debug functions which by default does nothing. This allows compiler
+// to optimize it out so it has no performance impact. If you want the output,
+// recompile with `-tags DEBUG`.
+func debug(s string, v ...interface{}) {}

--- a/vendor/github.com/Showmax/go-fqdn/log_debug.go
+++ b/vendor/github.com/Showmax/go-fqdn/log_debug.go
@@ -1,0 +1,12 @@
+// +build DEBUG
+
+package fqdn
+
+import "fmt"
+
+func debug(s string, v ...interface{}) {
+	if s[len(s)-1] != '\n' {
+		s += string('\n')
+	}
+	fmt.Printf(s, v...)
+}

--- a/vendor/github.com/Showmax/go-fqdn/util.go
+++ b/vendor/github.com/Showmax/go-fqdn/util.go
@@ -1,0 +1,20 @@
+package fqdn
+
+import (
+	"bufio"
+	"io"
+)
+
+// Read lines from r. It strips the line terminators and handles case when last
+// line is not terminated.
+func readline(r *bufio.Reader) (string, error) {
+	s, e := r.ReadString('\n')
+
+	if e == io.EOF && len(s) != 0 {
+		e = nil
+	}
+
+	s = chomp(s)
+
+	return s, e
+}

--- a/vendor/github.com/Showmax/go-fqdn/util_posix.go
+++ b/vendor/github.com/Showmax/go-fqdn/util_posix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package fqdn
+
+func chomp(s string) string {
+	if len(s) > 0 && s[len(s)-1] == '\n' {
+		s = s[:len(s)-1]
+	}
+
+	return s
+}

--- a/vendor/github.com/Showmax/go-fqdn/util_win.go
+++ b/vendor/github.com/Showmax/go-fqdn/util_win.go
@@ -1,0 +1,15 @@
+// +build windows
+
+package fqdn
+
+func chomp(s string) string {
+	if len(s) > 0 && s[len(s)-1] == '\n' {
+		s = s[:len(s)-1]
+	}
+
+	if len(s) > 0 && s[len(s)-1] == '\r' {
+		s = s[:len(s)-1]
+	}
+
+	return s
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/Showmax/go-fqdn v0.0.0-20180501083314-6f60894d629f
+# github.com/Showmax/go-fqdn v1.0.0
 ## explicit
 github.com/Showmax/go-fqdn
 # github.com/alexflint/go-arg v1.3.0


### PR DESCRIPTION
- Update `Showmax/fqdn` package from `v0.0.0-20180501083314-6f60894d629f` to `v1.0.0`.
- Update `EmailClientIdentity` method to use new API
  - Use new API provided by the `Showmax/fqdn` package for retrieving the FQDN for the host where this application is running.

fixes GH-167