### PR TITLE
Fix typo in configure doc

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -126,7 +126,7 @@ settings.
 | `ip-address`                    | `local_ip_address`       | `network`            |                                                                          |
 | `log-level`                     | `level`                  | `logging`            |                                                                          |
 | `log-format`                    | `format`                 | `logging`            |                                                                          |
-| `log-out`                       | `output`                 | `logging`            |                                                                          |
+| `log-output`                    | `output`                 | `logging`            |                                                                          |
 | `disabled-users-file`           | `file_path`              | `disabledusers`      |                                                                          |
 | `disabled-users-file-perms`     | `file_permissions`       | `disabledusers`      |                                                                          |
 | `disabled-users-entry-suffix`   | `entry_suffix`           | `disabledusers`      |                                                                          |


### PR DESCRIPTION
The flag `log-output` was incorrectly noted as `log-out` in the flag quick-reference column for the config file settings.

fixes GH-176