### PR TITLE
Restore explicit exit code handling

### DIFF
--- a/cmd/brick/main.go
+++ b/cmd/brick/main.go
@@ -41,9 +41,24 @@ func main() {
 	// implementation work
 	goteamsnotify.DisableLogging()
 
+	// Emulate returning exit code from main function by "queuing up" a
+	// default exit code that matches expectations, but allow explicitly
+	// setting the exit code in such a way that is compatible with using
+	// deferred function calls throughout the application.
+	var appExitCode *int
+	defer func(code *int) {
+		var exitCode int
+		if code != nil {
+			exitCode = *code
+		}
+		os.Exit(exitCode)
+	}(appExitCode)
+
 	appConfig, err := config.NewConfig()
 	if err != nil {
-		log.Fatalf("Failed to initialize application: %s", err)
+		log.Errorf("Failed to initialize application: %s", err)
+		*appExitCode = 1
+		return
 	}
 	log.Debug("Initializing application")
 
@@ -175,6 +190,7 @@ func main() {
 		// any other error message.
 		if !errors.Is(err, http.ErrServerClosed) {
 			log.Errorf("error occurred while running httpServer: %v", err)
+			*appExitCode = 1
 			return
 		}
 	}


### PR DESCRIPTION
This commit restores the error handling behavior for the
ListenAndServe code block to allow return of an explicit
error code to the OS (i.e., the process manager)

This behavior was restored by using an initial defer of a
pointer to int with a default value that indicates success.
This can be overridden as needed (and currently is)
to indicate application failure without blocking other
deferred functions from running.

refs GH-179