### PR TITLE
Correct the version of Go noted for v0.4.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ The following types of changes will be recorded in this file:
 ### Changed
 
 - Statically linked binary release
-  - Built using Go 1.15.3
+  - Built using Go 1.15.4
   - Windows
     - x86
     - x64


### PR DESCRIPTION
Go 1.15.4 was used to build the binaries, not 1.15.3 as noted.