### PR TITLE
Fix explicit exit code handling

### DIFF
--- a/cmd/brick/main.go
+++ b/cmd/brick/main.go
@@ -45,19 +45,19 @@ func main() {
 	// default exit code that matches expectations, but allow explicitly
 	// setting the exit code in such a way that is compatible with using
 	// deferred function calls throughout the application.
-	var appExitCode *int
+	var appExitCode int
 	defer func(code *int) {
 		var exitCode int
 		if code != nil {
 			exitCode = *code
 		}
 		os.Exit(exitCode)
-	}(appExitCode)
+	}(&appExitCode)
 
 	appConfig, err := config.NewConfig()
 	if err != nil {
 		log.Errorf("Failed to initialize application: %s", err)
-		*appExitCode = 1
+		appExitCode = 1
 		return
 	}
 	log.Debug("Initializing application")
@@ -200,7 +200,7 @@ func main() {
 		// any other error message.
 		if !errors.Is(err, http.ErrServerClosed) {
 			log.Errorf("error occurred while running httpServer: %v", err)
-			*appExitCode = 1
+			appExitCode = 1
 			return
 		}
 	}


### PR DESCRIPTION
Avoid assignment to uninitialized pointer by using a value
type and explicitly passing a reference to the value type
into the deferred anonymous function. This allows the
intended behavior to work as expected.

refs GH-179
refs GH-191