### PR TITLE
Fix deferred log call formatting

### DIFF
--- a/internal/files/process.go
+++ b/internal/files/process.go
@@ -593,18 +593,19 @@ func appendToFile(entry fileEntry, tmpl *template.Template, filename string, per
 			opErr,
 		)
 	}
-	defer func() {
+	defer func(filename string) {
 		if err := f.Close(); err != nil {
 			// Ignore "file already closed" errors
 			if !errors.Is(err, os.ErrClosed) {
 				log.Errorf(
 					"%s: failed to close file %q: %s",
 					myFuncName,
+					filename,
 					err.Error(),
 				)
 			}
 		}
-	}()
+	}(filename)
 	log.Debugf("%s: Successfully opened %q", myFuncName, filename)
 
 	log.Debugf("%s: Locking mutex", myFuncName)


### PR DESCRIPTION
- Add missing variable in string formatting reference
- Pass needed value as argument to deferred anonymous function