### PR TITLE
files.appendToFile: Fix invalid error var reference

### DIFF
--- a/internal/files/process.go
+++ b/internal/files/process.go
@@ -620,7 +620,7 @@ func appendToFile(entry fileEntry, tmpl *template.Template, filename string, per
 
 		// if there were template execution errors, go ahead and try to close
 		// the file before returning the template write error
-		if fileCloseErr := f.Close(); tmplErr != nil {
+		if fileCloseErr := f.Close(); fileCloseErr != nil {
 
 			// log this error, return Write error as it takes precedence
 			log.Errorf(


### PR DESCRIPTION
Prior to this commit, the template execute error was checked twice instead of checking the file close error after already determining that there was a template execute error.