### PR TITLE
Re-enable deprecated maligned linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,11 @@ linters:
     - depguard
     - prealloc
     - misspell
+
+    # Deprecated linter, but still functional as of golangci-lint v1.39.0.
+    # See https://github.com/atc0005/go-ci/issues/302 for more information.
+    - maligned
+
     - dupl
     - unconvert
     - gofmt
@@ -40,10 +45,18 @@ linters:
     - gocritic
     - exportloopref
 
-  disable:
-    - maligned
+#
+# Disable fieldalignment settings until the Go team offers more control over
+# the types of checks provided by the fieldalignment linter or golangci-lint
+# does so.
+#
+# See https://github.com/atc0005/go-ci/issues/302 for more information.
+#
 
-linters-settings:
-  govet:
-    enable:
-      - fieldalignment
+# disable:
+# - maligned
+
+# linters-settings:
+# govet:
+#   enable:
+#     - fieldalignment


### PR DESCRIPTION
Disable govet:fieldalignment, re-enable deprecated maligned
linter until the Go team offers more control over the types
of checks provided by the fieldalignment linter or
golangci-lint does so.

- refs GH-218
- refs GH-219
- refs GH-220
- refs atc0005/go-ci#302