### PR TITLE
Replace use of deprecated function

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -220,8 +220,11 @@ func validate(c Config) error {
 	if c.TeamsWebhookURL() != "" {
 		log.Debugf("Microsoft Teams WebhookURL provided: %v", c.TeamsWebhookURL())
 
-		if ok, err := goteamsnotify.IsValidWebhookURL(c.TeamsWebhookURL()); !ok {
-			return err
+		// Create Microsoft Teams client
+		mstClient := goteamsnotify.NewClient()
+
+		if err := mstClient.ValidateWebhook(c.TeamsWebhookURL()); err != nil {
+			return fmt.Errorf("webhook URL validation failed: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Use `API.ValidateWebhook() method` in place of package-level `goteamsnotify.IsValidWebhookURL` function which was deprecated in v2.5.0 of `atc0005/go-teams-notify`.

fixes GH-222