### PR TITLE
Fix version var placeholder substitution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ WHAT 					= brick es ezproxy
 # What package holds the "version" variable used in branding/version output?
 # VERSION_VAR_PKG			= $(shell go list .)
 # VERSION_VAR_PKG			= main
-VERSION_VAR_PKG			= $(shell go list .)/config
+VERSION_VAR_PKG			= $(shell go list .)/internal/config
 
 OUTPUTDIR 				= release_assets
 


### PR DESCRIPTION
Evidently I missed updating the Makefile when I moved the
config package into the `internal` subdirectory.

refs GH-226