### PR TITLE
Ignore false-positive gosec G307 linting errors

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -246,6 +246,10 @@ func NewConfig() (*Config, error) {
 				err,
 			)
 		}
+
+		// #nosec G307
+		// Believed to be a false-positive from recent gosec release
+		// https://github.com/securego/gosec/issues/714
 		defer func() {
 			if err := fh.Close(); err != nil {
 				// Ignore "file already closed" errors

--- a/internal/files/process.go
+++ b/internal/files/process.go
@@ -593,6 +593,10 @@ func appendToFile(entry fileEntry, tmpl *template.Template, filename string, per
 			opErr,
 		)
 	}
+
+	// #nosec G307
+	// Believed to be a false-positive from recent gosec release
+	// https://github.com/securego/gosec/issues/714
 	defer func(filename string) {
 		if err := f.Close(); err != nil {
 			// Ignore "file already closed" errors

--- a/internal/fileutils/contains.go
+++ b/internal/fileutils/contains.go
@@ -53,6 +53,10 @@ func HasLine(searchTerm string, ignorePrefix string, filename string) (bool, err
 			err,
 		)
 	}
+
+	// #nosec G307
+	// Believed to be a false-positive from recent gosec release
+	// https://github.com/securego/gosec/issues/714
 	defer func() {
 		if err := f.Close(); err != nil {
 			// Ignore "file already closed" errors


### PR DESCRIPTION
Issues reported after upgrading golangci-lint to v1.43.0.
gosec was updated in that version from v2.8.1 to v2.9.1.

fixes atc0005/brick#261
refs golangci/golangci-lint#2299