### PR TITLE
Update lintinstall Makefile recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,8 @@ lintinstall:
 
 	@export PATH="${PATH}:$(go env GOPATH)/bin"
 
-	@echo "Explicitly enabling Go modules mode per command"
-	(cd; GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck)
+	@echo "Installing latest stable staticcheck version via go install command ..."
+	@go install honnef.co/go/tools/cmd/staticcheck@latest
 
 	@echo Installing latest stable golangci-lint version per official installation script ...
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin


### PR DESCRIPTION
Use `go install` instead of `go get` to resolve deprecation error with Go 1.18+.