### PR TITLE
Update project to Go 1.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,5 +90,5 @@ updates:
         versions:
           # Ignore updates from series associated with the latest "stable"
           # Go release and no longer supported Go versions.
-          - ">= 1.18"
-          - "< 1.17"
+          - ">= 1.20"
+          - "< 1.19"

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -23,4 +23,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.17.13
+FROM golang:1.19.0

--- a/doc.go
+++ b/doc.go
@@ -1,16 +1,13 @@
 /*
-
 brick automatically disables EZproxy accounts via incoming webhook requests.
 
-
-
-PROJECT HOME
+# Project Home
 
 See our GitHub repo (https://github.com/atc0005/brick) for the latest code, to
 file an issue or submit improvements for review and potential inclusion into
 the project.
 
-PURPOSE
+# Purpose
 
 This application is intended to be used as a HTTP endpoint that runs alongside
 an EZproxy instance. This endpoint receives webhook requests from a monitoring
@@ -20,8 +17,8 @@ notifications listing the action taken. At this point, the associated user
 sessions can be optionally (and automatically) terminated using two
 approaches:
 
-(1) using (not officially documented) EZproxy binary subcommand
-(2) using the provided fail2ban config files
+ 1. using (not officially documented) EZproxy binary subcommand
+ 2. using the provided fail2ban config files
 
 If using native termination support, all active user sessions associated with
 the reported username will be terminated using the kill subcommand provided by
@@ -42,32 +39,28 @@ NOTE: This application has not been designed to identify user accounts
 directly, but rather relies on other systems (currently limited to Splunk) to
 make the decision as to which accounts should be disabled.
 
-FEATURES
+# Features
 
-• Highly configurable (with more configuration choices to be exposed in the future)
+  - Highly configurable (with more configuration choices to be exposed in the
+    future)
+  - Supports configuration settings from multiple sources (command-line flags,
+    environment variables, configuration file, reasonable default settings)
+  - User configurable logging settings (levels, format, output)
+  - User configurable support for ignoring specific usernames (i.e., prevent
+    disabling listed accounts)
+  - User configurable support for ignoring specific IP Addresses (i.e.,
+    prevent disabling associated account)
+  - Logging of all events (e.g., payload receipt, action taken due to payload)
+  - Optional Microsoft Teams notifications generated for multiple events with
+    configurable rate limit, notification retries, and retry delay
+  - Optional email notifications generated for multiple events with
+    configurable rate limit, notification retries, and retry delay
+  - Optional automatic (but not officially documented) termination of user
+    sessions via official EZproxy binary
+  - Optional filtering of JSON payload sender IP Addresses
 
-• Supports configuration settings from multiple sources (command-line flags, environment variables, configuration file, reasonable default settings)
-
-• User configurable logging settings (levels, format, output)
-
-• User configurable support for ignoring specific usernames (i.e., prevent disabling listed accounts)
-
-• User configurable support for ignoring specific IP Addresses (i.e., prevent disabling associated account)
-
-• Logging of all events (e.g., payload receipt, action taken due to payload)
-
-• Optional Microsoft Teams notifications generated for multiple events with configurable rate limit, notification retries, and retry delay
-
-* Optional email notifications generated for multiple events with configurable rate limit, notification retries, and retry delay
-
-• Optional automatic (but not officially documented) termination of user sessions via official EZproxy binary
-
-• Optional filtering of JSON payload sender IP Addresses
-
-USAGE
+# Usage
 
 See the README for examples.
-
-
 */
 package main

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ module github.com/atc0005/brick
 
 // replace github.com/atc0005/go-ezproxy => ../go-ezproxy
 
-go 1.17
+go 1.19
 
 require (
 	github.com/Showmax/go-fqdn v1.0.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,7 +141,6 @@ func (c configTemplate) Description() string {
 //
 // This computed timeout value is intended to be used to cancel a notification
 // attempt once it reaches this timeout threshold.
-//
 func GetNotificationTimeout(
 	baseTimeout time.Duration,
 	schedule time.Time,

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -256,7 +256,8 @@ const (
 	LogLevelDebug string = "debug"
 )
 
-// 	apex/log Handlers
+// apex/log Handlers
+//
 // ---------------------------------------------------------
 // cli - human-friendly CLI output
 // discard - discards all logs


### PR DESCRIPTION
- update go.mod file from Go 1.17 to 1.19
- update doc.go file to use Go 1.19 package doc comments syntax
- update config package files to use Go 1.19 linting fixes
- update "Canary" Dockerfile to reflect current Go 1.19 version
- update Dependabot configuration for Dockerfile to ignore Go
  releases outside of the Go 1.19 release series