### PR TITLE
Update Makefile and GitHub Actions Workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,78 @@
+# Copyright 2021 Adam Chalkley
+#
+# https://github.com/atc0005/brick
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
+  schedule:
+    - cron: "19 2 * * 3"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["go"]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
+        # Learn more:
+        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2.1.22
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2.1.22
+
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
+
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
+
+      #- run: |
+      #   make bootstrap
+      #   make release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2.1.22

--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -57,13 +57,17 @@ jobs:
           rm -vf .golangci.yml
 
       - name: Run golangci-lint using container-provided config file settings
-        run: golangci-lint run -v
+        run: |
+          golangci-lint --version
+          golangci-lint run
 
       # This is the very latest stable version of staticcheck provided by the
       # atc0005/go-ci container. The version included with golangci-lint often
       # lags behind the official stable releases.
       - name: Run staticcheck
-        run: staticcheck $(go list -mod=vendor ./... | grep -v /vendor/)
+        run: |
+          staticcheck --version
+          staticcheck $(go list -mod=vendor ./... | grep -v /vendor/)
 
   test_code:
     name: Run tests

--- a/.github/workflows/lint-and-test-only.yml
+++ b/.github/workflows/lint-and-test-only.yml
@@ -42,7 +42,30 @@ jobs:
           rm -vf .golangci.yml
 
       - name: Run golangci-lint using container-provided config file settings
-        run: golangci-lint run -v
+        run: |
+          golangci-lint --version
+          golangci-lint run
 
       - name: Run all tests
         run: go test -mod=vendor -v ./...
+
+  go_mod_changes:
+    name: Look for uncommitted Go module changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: ghcr.io/atc0005/go-ci:go-ci-lint-only
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: go mod tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod
+
+      - name: go mod vendor
+        run: |
+          go mod vendor
+          git diff --exit-code vendor/

--- a/.github/workflows/lint-docker-files.yml
+++ b/.github/workflows/lint-docker-files.yml
@@ -37,4 +37,5 @@ jobs:
 
       - name: Run hadolint against all Dockerfile files
         run: |
+          hadolint --version
           hadolint dependabot/docker/go/Dockerfile

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           npm install markdownlint --save-dev
           npm install -g markdownlint-cli
+          echo "markdownlint version: $(markdownlint --version)"
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -53,4 +54,5 @@ jobs:
         # potential linting issues in bundled documentation to fail linting CI
         # runs for *our* documentation
         run: |
+          echo "markdownlint version: $(markdownlint --version)"
           markdownlint '**/*.md' --ignore node_modules --ignore vendor

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,38 +25,20 @@ issues:
 
 linters:
   enable:
+    - depguard
     - dogsled
+    - dupl
+    - exportloopref
+    - goconst
+    - gocritic
+    - gofmt
     - goimports
     - gosec
-    - stylecheck
-    - goconst
-    - depguard
-    - prealloc
-    - misspell
-
-    # Deprecated linter, but still functional as of golangci-lint v1.39.0.
-    # See https://github.com/atc0005/go-ci/issues/302 for more information.
+    - govet
     - maligned
-
-    - dupl
+    - misspell
+    - prealloc
+    - revive
+    - staticcheck
+    - stylecheck
     - unconvert
-    - gofmt
-    - golint
-    - gocritic
-    - exportloopref
-
-#
-# Disable fieldalignment settings until the Go team offers more control over
-# the types of checks provided by the fieldalignment linter or golangci-lint
-# does so.
-#
-# See https://github.com/atc0005/go-ci/issues/302 for more information.
-#
-
-# disable:
-# - maligned
-
-# linters-settings:
-# govet:
-#   enable:
-#     - fieldalignment

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,8 @@ lintinstall:
 	@export PATH="${PATH}:$(go env GOPATH)/bin"
 
 	@echo "Installing latest stable staticcheck version via go install command ..."
-	@go install honnef.co/go/tools/cmd/staticcheck@latest
+	go install honnef.co/go/tools/cmd/staticcheck@latest
+	staticcheck --version
 
 	@echo Installing latest stable golangci-lint version per official installation script ...
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin
@@ -121,9 +122,11 @@ linting:
 	@go vet -mod=vendor $(shell go list -mod=vendor ./... | grep -v /vendor/)
 
 	@echo "Running golangci-lint ..."
+	@golangci-lint --version
 	@golangci-lint run
 
 	@echo "Running staticcheck ..."
+	@staticcheck --version
 	@staticcheck $(shell go list -mod=vendor ./... | grep -v /vendor/)
 
 	@echo "Finished running linting checks"


### PR DESCRIPTION
- echo hadolint version
- echo golangci-lint version
- echo staticcheck version
- echo markdownlint-cli version
- add `go_mod_changes` job to test for uncommitted `go mod tidy`
  and `go mod vendor` changes
- update repo-bundled golangci-lint configuration to replace (most)
  deprecated linters
  - `golint` to `revive`
  - `scopelint` to `exportloopref`
- enable additional linters that I already use within the
  atc0005/go-ci stable images.
  - `govet`
  - `staticcheck`
- add CodeQL GitHub Actions Workflow